### PR TITLE
Support polling for metrics without requiring own /metrics listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.sw?
+.bundle/
+vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 120
 
+Metrics/MethodLength:
+  Max: 12
+
 Style/Documentation:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,14 +5,19 @@ Naming/FileName:
   Exclude:
     - puma-metrics.gemspec
 
+Metrics/BlockLength:
+  Max: 45
+
 Metrics/LineLength:
   Max: 120
 
 Style/Documentation:
   Enabled: false
+
 Style/MethodMissingSuper:
   Exclude:
     - lib/puma/metrics/parser.rb
+
 Style/MissingRespondToMissing:
   Exclude:
     - lib/puma/metrics/parser.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+Features:
+- Upgrade `puma` version
+
 ## 1.1.0
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+Features:
+- Implement support for polling for metrics via `metrics_poll`
+- Support disabling of metrics listener via `metrics_url off`
+
 ## 1.0.1
 
 Bugfixes:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    puma-metrics (1.0.1)
+    puma-metrics (1.1.0)
       prometheus-client (~> 0.8)
       puma (~> 3.0)
 
@@ -22,7 +22,7 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    prometheus-client (0.8.0)
+    prometheus-client (0.9.0)
       quantile (~> 0.2.1)
     puma (3.12.0)
     quantile (0.2.1)
@@ -51,4 +51,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ plugin 'metrics'
 #
 # The default is "tcp://0.0.0.0:9393".
 # metrics_url 'tcp://0.0.0.0:9393'
+
+# Instead of creating a metric server, internally poll, using the configured
+# interval in seconds, for the Puma metrics and assume that the Rails app
+# itself provides a `/metrics` endpoint for exporting.
+# metrics_poll 15
+# metrics_url 'false'
 ```
 
 ## Credits

--- a/lib/puma/metrics/app.rb
+++ b/lib/puma/metrics/app.rb
@@ -12,12 +12,16 @@ module Puma
       end
 
       def call(_env)
-        @parser.parse JSON.parse(@launcher.stats)
+        parse
         [
           200,
           { 'Content-Type' => 'text/plain' },
           [Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
         ]
+      end
+
+      def parse
+        @parser.parse JSON.parse(@launcher.stats)
       end
     end
   end

--- a/lib/puma/metrics/app.rb
+++ b/lib/puma/metrics/app.rb
@@ -6,9 +6,8 @@ module Puma
   module Metrics
     class App
       def initialize(launcher)
-        @launcher = launcher
-        clustered = (@launcher.options[:workers] || 0) > 0
-        @parser = Parser.new clustered
+        clustered = (launcher.options[:workers] || 0) > 0
+        @parser = Parser.new(clustered)
       end
 
       def call(_env)
@@ -21,7 +20,7 @@ module Puma
       end
 
       def parse
-        @parser.parse JSON.parse(@launcher.stats)
+        @parser.parse(JSON.parse(Puma.stats)
       end
     end
   end

--- a/lib/puma/metrics/dsl.rb
+++ b/lib/puma/metrics/dsl.rb
@@ -1,5 +1,9 @@
 module Puma
   class DSL
+    def metrics_poll(poll)
+      @options[:metrics_poll] = poll.to_i
+    end
+
     def metrics_url(url)
       @options[:metrics_url] = url
     end

--- a/lib/puma/metrics/version.rb
+++ b/lib/puma/metrics/version.rb
@@ -1,5 +1,5 @@
 module Puma
   module Metrics
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end

--- a/lib/puma/metrics/version.rb
+++ b/lib/puma/metrics/version.rb
@@ -1,5 +1,5 @@
 module Puma
   module Metrics
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/lib/puma/metrics/version.rb
+++ b/lib/puma/metrics/version.rb
@@ -1,5 +1,5 @@
 module Puma
   module Metrics
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/lib/puma/plugin/metrics.rb
+++ b/lib/puma/plugin/metrics.rb
@@ -3,23 +3,37 @@ require 'puma/metrics/dsl'
 Puma::Plugin.create do
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def start(launcher)
-    str = launcher.options[:metrics_url] || 'tcp://0.0.0.0:9393'
+    metrics_url = launcher.options[:metrics_url] || 'tcp://0.0.0.0:9393'
+    metrics_poll = launcher.options[:metrics_poll] || 0
+
+    metrics_url_disabled = %w[off none false].include?(metrics_url.downcase)
+
+    # If the metrics URL, and polling, are both disabled, then return.
+    return if metrics_url_disabled && metrics_poll.zero?
 
     require 'puma/metrics/app'
 
-    app = Puma::Metrics::App.new launcher
-    uri = URI.parse str
+    @app = Puma::Metrics::App.new launcher
 
-    metrics = Puma::Server.new app, launcher.events
+    if metrics_url_disabled
+      poll(metrics_poll)
+    else
+      listen(launcher, metrics_url)
+    end
+  end
+
+  def listen(launcher, metrics_url)
+    metrics = Puma::Server.new @app, launcher.events
     metrics.min_threads = 0
     metrics.max_threads = 1
 
+    uri = URI.parse metrics_url
     case uri.scheme
     when 'tcp'
-      launcher.events.log "* Starting metrics server on #{str}"
+      launcher.events.log "* Starting metrics server on #{metrics_url}"
       metrics.add_tcp_listener uri.host, uri.port
     else
-      launcher.events.error "Invalid control URI: #{str}"
+      launcher.events.error "Invalid control URI: #{metrics_url}"
     end
 
     launcher.events.register(:state) do |state|
@@ -30,6 +44,15 @@ Puma::Plugin.create do
     end
 
     metrics.run
+  end
+
+  def poll(metrics_poll)
+    in_background do
+      loop do
+        sleep metrics_poll
+        @app.parse
+      end
+    end
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 end

--- a/puma-metrics.gemspec
+++ b/puma-metrics.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   spec.add_runtime_dependency 'prometheus-client', '~> 0.8'
-  spec.add_runtime_dependency 'puma', '~> 3.0'
+  spec.add_runtime_dependency 'puma', '~> 4.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest'

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -5,6 +5,21 @@ require 'puma/configuration'
 class TestConfig < Minitest::Test
   include Helpers
 
+  def test_metrics_poll
+    configuration = Puma::Configuration.new do |config|
+      config.bind 'tcp://127.0.0.1:0'
+      config.plugin 'metrics'
+      config.metrics_poll 1
+      config.metrics_url 'false'
+      config.quiet
+      config.app { [200, {}, ['hello world']] }
+    end
+
+    start_server(configuration)
+    assert_raises(Errno::ECONNREFUSED) { response }
+    stop_server
+  end
+
   def test_default_metrics_url
     configuration = Puma::Configuration.new do |config|
       config.bind 'tcp://127.0.0.1:0'
@@ -15,6 +30,20 @@ class TestConfig < Minitest::Test
 
     start_server(configuration)
     assert_includes response, '# TYPE puma_backlog gauge'
+    stop_server
+  end
+
+  def test_metrics_url_disabled
+    configuration = Puma::Configuration.new do |config|
+      config.bind 'tcp://127.0.0.1:0'
+      config.plugin 'metrics'
+      config.metrics_url 'false'
+      config.quiet
+      config.app { [200, {}, ['hello world']] }
+    end
+
+    start_server(configuration)
+    assert_raises(Errno::ECONNREFUSED) { response }
     stop_server
   end
 


### PR DESCRIPTION
In our use case, we have Rails applications that already provide a `/metrics` URI, protected with HTTP Basic Authentication.  As such, we want to continue using our `/metrics` listener, but also to obtain the Puma metrics via Prometheus.

This PR allows for disabling the `metrics_url`, _and_ for scheduling an internal polling interval, for obtaining the Puma metrics and updating the Prometheus registry.