### PR TITLE
terminate metrics server without IO errors

### DIFF
--- a/lib/puma/plugin/metrics.rb
+++ b/lib/puma/plugin/metrics.rb
@@ -24,8 +24,7 @@ Puma::Plugin.create do
 
     launcher.events.register(:state) do |state|
       if %i[halt restart stop].include?(state)
-        metrics.stop
-        metrics.binder.close
+        metrics.stop(true) unless metrics.shutting_down?
       end
     end
 


### PR DESCRIPTION
Ctrl-C would print several errors when shutting down the metrics server.

```
Use Ctrl-C to stop
^C2019-04-11 11:30:59 +0200: Listen loop error: #<Errno::EBADF: Bad file descriptor>
puma-3.12.1/lib/puma/server.rb:386:in `select'
puma-3.12.1/lib/puma/server.rb:386:in `handle_servers'
puma-3.12.1/lib/puma/server.rb:360:in `block in run'
2019-04-11 11:30:59 +0200: Listen loop error: #<IOError: closed stream>
puma-3.12.1/lib/puma/server.rb:386:in `select'
puma-3.12.1/lib/puma/server.rb:386:in `handle_servers'
puma-3.12.1/lib/puma/server.rb:360:in `block in run'

2019-04-11 11:30:59 +0200: Listen loop error: #<IOError: closed stream>
gems/puma-3.12.1/lib/puma/server.rb:386:in `select'
gems/puma-3.12.1/lib/puma/server.rb:386:in `handle_servers'
puma-3.12.1/lib/puma/server.rb:360:in `block in run'
```

The state handler would be triggered twice, so it should check if it executed already.