### PR TITLE
Relax prometheus-client dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Pending
+
+Changes:
+- Relax prometheus-client to '>= 0.10'
+
 ## 1.1.0
 
 Changes:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     puma-metrics (1.1.0)
-      prometheus-client (~> 0.10)
+      prometheus-client (>= 0.10)
       puma (>= 3.0)
 
 GEM
@@ -17,15 +17,15 @@ GEM
     overcommit (0.51.0)
       childprocess (>= 0.6.3, < 4)
       iniparse (~> 1.4)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    prometheus-client (0.10.0)
-    puma (4.2.1)
+    prometheus-client (1.0.0)
+    puma (4.3.1)
       nio4r (~> 2.0)
     rainbow (3.0.0)
-    rake (13.0.0)
-    rubocop (0.76.0)
+    rake (13.0.1)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)

--- a/puma-metrics.gemspec
+++ b/puma-metrics.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
 
-  spec.add_runtime_dependency 'prometheus-client', '~> 0.10'
+  spec.add_runtime_dependency 'prometheus-client', '>= 0.10'
   spec.add_runtime_dependency 'puma', '>= 3.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
This allows puma-metrics to be used in conjunction with `prometheus-client-1.x`.

Closes #16.