### PR TITLE
Allow use of Hash-shaped stats

### DIFF
--- a/lib/puma/metrics/app.rb
+++ b/lib/puma/metrics/app.rb
@@ -14,12 +14,21 @@ module Puma
       end
 
       def call(_env)
-        @parser.parse JSON.parse(@launcher.stats)
+        retrieve_and_parse_stats!
         [
           200,
           { 'Content-Type' => 'text/plain' },
           [Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
         ]
+      end
+
+      def retrieve_and_parse_stats!
+        puma_stats = @launcher.stats
+        if puma_stats.is_a?(Hash) # Modern Puma outputs stats as a Symbol-keyed Hash
+          @parser.parse(puma_stats)
+        else
+          @parser.parse(JSON.parse(puma_stats, symbolize_names: true))
+        end
       end
     end
   end

--- a/lib/puma/metrics/parser.rb
+++ b/lib/puma/metrics/parser.rb
@@ -10,10 +10,10 @@ module Puma
         register_clustered_metrics if clustered
       end
 
-      def parse(stats, labels = {})
-        stats.each do |key, value|
-          value.each { |s| parse(s, labels.merge(index: s['index'])) } if key == 'worker_status'
-          parse(value, labels) if key == 'last_status'
+      def parse(symbol_keyed_stats, labels = {})
+        symbol_keyed_stats.each do |key, value|
+          value.each { |s| parse(s, labels.merge(index: s[:index])) } if key == :worker_status
+          parse(value, labels) if key == :last_status
           update_metric(key, value, labels)
         end
       end


### PR DESCRIPTION
As of https://github.com/puma/puma/pull/2086 Puma will be outputting a Hash instead
of a string of JSON, so the parsing step is not going to be needed. This allows
some additional uses of the stats such as shuttling extra data from workers to the
master process. These will be possible to pick up on Prometheus as well if they get
registered by the user.

Update key use to always use symbols, since this allows
better object reuse (and the builtin #stats method will be
returning Symbol-keyed hashes natively)