### PR TITLE
Moved registry definition into a new Config module so that it can be set at the plugin level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Changes:
+- Added a config class
+- Moved the prometheus registry to the config class so it can be overridden by alternative plugins.
+
 ## 1.2.2
 
 Changes:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ plugin 'metrics'
 # metrics_url 'tcp://0.0.0.0:9393'
 ```
 
+## Testing
+
+Run
+
+```ruby
+bundle exec rake test
+```
+
 ## Credits
 
 The gem is inspired by the following projects:

--- a/lib/puma/metrics/app.rb
+++ b/lib/puma/metrics/app.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'prometheus/client/formats/text'
+require 'puma/metrics/config'
 require 'puma/metrics/parser'
 
 module Puma
@@ -18,7 +19,7 @@ module Puma
         [
           200,
           { 'Content-Type' => 'text/plain' },
-          [Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
+          [Prometheus::Client::Formats::Text.marshal(Puma::Metrics::Config.registry)]
         ]
       end
 

--- a/lib/puma/metrics/config.rb
+++ b/lib/puma/metrics/config.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Puma
+  module Metrics
+    module Config
+      class << self
+        attr_accessor :registry
+      end
+    end
+  end
+end

--- a/lib/puma/metrics/dsl.rb
+++ b/lib/puma/metrics/dsl.rb
@@ -5,5 +5,11 @@ module Puma
     def metrics_url(url)
       @options[:metrics_url] = url
     end
+
+    attr_writer :registry
+
+    def registry
+      @registry || Prometheus::Client.registry
+    end
   end
 end

--- a/lib/puma/metrics/parser.rb
+++ b/lib/puma/metrics/parser.rb
@@ -56,7 +56,7 @@ module Puma
       end
 
       def registry
-        Prometheus::Client.registry
+        Puma::Metrics::Config.registry
       end
 
       def update_metric(key, value, labels)

--- a/lib/puma/plugin/metrics.rb
+++ b/lib/puma/plugin/metrics.rb
@@ -9,6 +9,7 @@ Puma::Plugin.create do
 
     require 'puma/metrics/app'
 
+    Puma::Metrics::Config.registry = Prometheus::Client.registry
     app = Puma::Metrics::App.new launcher
     uri = URI.parse str
 


### PR DESCRIPTION
Quick and dirty code change to move the registry definition to a centralized place and allow it to be changed outside the gem.

My use case will involve a custom plugin with some funkiness around the prometheus registry management.

I am interested in feedback on code style and the best way to test.