### PR TITLE
shut down in on_stopped so metrics server is running whenever puma is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Changes:
+- Shut down metrics server in on_stopped so it only stops when main puma process stops and ignores when workers are stopped. This allows us to maintain a running metrics server when workers restart or crash.
+
 ## 1.2.3
 
 Housekeeping:

--- a/lib/puma/plugin/metrics.rb
+++ b/lib/puma/plugin/metrics.rb
@@ -24,12 +24,8 @@ Puma::Plugin.create do
       launcher.events.error "Invalid control URI: #{str}"
     end
 
-    launcher.events.register(:state) do |state|
-      if %i[halt restart stop].include?(state)
-        # rubocop:disable Style/SoleNestedConditional
-        metrics.stop(true) unless metrics.shutting_down?
-        # rubocop:enable Style/SoleNestedConditional
-      end
+    launcher.events.on_stopped do
+      metrics.stop(true) unless metrics.shutting_down?
     end
 
     metrics.run


### PR DESCRIPTION
Shut down metrics server in on_stopped so it only stops when main puma process stops and ignores when workers are stopped. This allows us to maintain a running metrics server when workers restart or crash.

To replicate issue, start up puma server with multiple workers, kill one of the workers, and notice that the metrics endpoint no longer works.