### PR TITLE
set puma dependency to min 5.0

### DIFF
--- a/puma-metrics.gemspec
+++ b/puma-metrics.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_runtime_dependency 'prometheus-client', '>= 0.10'
-  spec.add_runtime_dependency 'puma', '>= 3.0'
+  spec.add_runtime_dependency 'puma', '>= 5.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest'


### PR DESCRIPTION
the event `on_stopped` was introduced with puma 5.0