### PR TITLE
CI: Tell dependabot to keep GH Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Perhaps this is nicer than a pin to @master – idk.

This PR adds a configuration to tell Dependabot to update the versions used for some well-known GitHub Actions, such as `checkout`, in order to avoid deprecation warnings when those get too old. [Documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)