### PR TITLE
CI: Use bundler-cache from ruby/setup-ruby

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,8 +13,7 @@ jobs:
     - uses: ruby/setup-ruby@master
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: gem install bundler
-    - run: bundle install
+        bundler-cache: true # 'bundle install' and cache gems
     - run: bundle exec rake
     - run: bundle exec overcommit --sign
     - env:


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.