### PR TITLE
Deal with server not ready gracefully

### DIFF
--- a/lib/puma/metrics/app.rb
+++ b/lib/puma/metrics/app.rb
@@ -6,6 +6,8 @@ require 'puma/metrics/parser'
 
 module Puma
   module Metrics
+    MetricsNotAvailableError = Class.new(StandardError)
+
     class App
       def initialize(launcher)
         @launcher = launcher
@@ -20,15 +22,35 @@ module Puma
           { 'Content-Type' => 'text/plain' },
           [Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry)]
         ]
+      rescue MetricsNotAvailableError => e
+        [503, { 'Content-Type' => 'text/plain' }, ["#{e.message}\n"]]
       end
 
       def retrieve_and_parse_stats!
-        puma_stats = @launcher.stats
+        puma_stats = fetch_stats
         if puma_stats.is_a?(Hash) # Modern Puma outputs stats as a Symbol-keyed Hash
           @parser.parse(puma_stats)
         else
           @parser.parse(JSON.parse(puma_stats, symbolize_names: true))
         end
+      end
+
+      private
+
+      def fetch_stats
+        @launcher.stats
+      rescue NoMethodError
+        # Puma plugins are started in the background along with the server, so
+        # there's a chance that a request will arrive to the server started by
+        # this plugin before the main one has been registered in the launcher.
+        #
+        # If that happens, fetching the stats fails because `@server` is nil,
+        # causing a NoMethodError.
+        #
+        # Ideally this code should detect the case using the launcher public
+        # interface, but no methods expose the information that is required for
+        # that.
+        raise MetricsNotAvailableError, 'Puma is booting up. Stats are not yet ready.'
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/harmjanblok/puma-metrics/issues/49

We've also observed this situation sometimes. 

This implements a simple solution, the response is still an error so prometheus should handle it as such, but an exception doesn't bubble up in the app.

I haven't been able to find a way to query any public interface offered by puma to identify the situation, so I'm capturing the exception. 

Testing is not straightforward since it depends on timing. One way to do it is to insert a `sleep 10` here: 

https://github.com/puma/puma/blob/8e7fab5f3992ef056dd9030a89da0372f933e5d4/lib/puma/single.rb#L51

With that, if we make a metrics request right after the app starts we see this code in action:

```
 $ curl -i localhost:9393
HTTP/1.1 503 Service Unavailable
Content-Type: text/plain
Content-Length: 45

Puma is booting up. Stats are not yet ready.
```

After 10 seconds requests return the regular prometheus payload:

```
$ curl -i localhost:9393
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 926

# TYPE puma_backlog gauge
...
```