### PR TITLE
Add Puma 6.6.0's `busy_threads` stat

### DIFF
--- a/lib/puma/metrics/parser.rb
+++ b/lib/puma/metrics/parser.rb
@@ -46,6 +46,10 @@ module Puma
                        docstring: 'Maximum number of worker threads',
                        labels: [:index],
                        preset_labels: { index: 0 })
+        registry.gauge(:puma_busy_threads,
+                       docstring: 'How saturated the worker threads are with requests',
+                       labels: [:index],
+                       preset_labels: { index: 0 })
         registry.gauge(:puma_requests_count,
                        docstring: 'Number of processed requests',
                        labels: [:index],

--- a/test/test_single.rb
+++ b/test/test_single.rb
@@ -33,6 +33,7 @@ class TestSingle < Minitest::Test
 
   def metrics
     [{ name: 'puma_backlog',        type: 'gauge', labels: l,  value: 0.0 },
+     { name: 'puma_busy_threads',   type: 'gauge', labels: [], value: 1.0 },
      { name: 'puma_max_threads',    type: 'gauge', labels: l,  value: 16.0 },
      { name: 'puma_pool_capacity',  type: 'gauge', labels: l,  value: 16.0 },
      { name: 'puma_requests_count', type: 'gauge', labels: l,  value: 0.0 },


### PR DESCRIPTION
In Puma 6.6.0 we got https://github.com/puma/puma/pull/3517, which introduced a new stat, `busy_threads`, defined as: 

> `running` - `how many threads are waiting to receive work` + `how many requests are waiting for a thread to pick them up`

This is an important signal to detect saturation of the web server with requests, so I've added it to the stats that puma-metrics emits. 